### PR TITLE
WIP: fix: Supports working with WSL

### DIFF
--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -2,3 +2,8 @@
  * Supported file extension types
  */
 export type FileExtension = ".gif" | ".jpeg" | ".jpg" | ".png" | ".webp";
+
+export interface DragFileInfo {
+    filepath: string;
+    base64: string;
+}


### PR DESCRIPTION
issue #1 の仮修正をしてみました。

* 独自の `basename` を作った（path としては、フルパスが来ると思うので、先頭が `/` なら Unix/Linux 系、そうでなければ Windows 系という決め打ち）
* `getDragFilePath` を書き換えて、ファイル名とbase64にエンコードした画像データを返すように修正（メソッド名も `getDragFile` に変更）
* 上記のために新しい型 `DragFileInfo` を作成

あまりキレイな修正ではない気がしますが、何かの参考になれば。